### PR TITLE
Fix go build failure with minimal main

### DIFF
--- a/go-api-tests/main.go
+++ b/go-api-tests/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
## Summary
- add an empty `main` function so `go build ./...` succeeds in CI

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854177bc2908325bbac52809e4c173b