### PR TITLE
Fix provider test by importing jest globals

### DIFF
--- a/pact-contract-testing/provider-api/provider.test.js
+++ b/pact-contract-testing/provider-api/provider.test.js
@@ -1,6 +1,7 @@
 import { Verifier } from '@pact-foundation/pact';
 import { server } from './server.js';
 import path from 'path';
+import { jest } from '@jest/globals';
 
 // Set a longer timeout for Pact verification
 jest.setTimeout(30000);


### PR DESCRIPTION
## Summary
- fix provider test by importing jest globals

## Testing
- `npm test` *(fails: Cannot find module 'jest' because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68545898884883258b4f2684adda4a12