### PR TITLE
Fix C# authentication response parsing

### DIFF
--- a/csharp-specflow-api-tests/Models/AuthResponse.cs
+++ b/csharp-specflow-api-tests/Models/AuthResponse.cs
@@ -2,11 +2,7 @@ namespace SpecFlowApiTests.Models
 {
     public class AuthResponse
     {
-        public string? Token { get; }
-
-        public AuthResponse(string? token)
-        {
-            Token = token;
-        }
+        // NOTE: setter needed for System.Text.Json deserialization
+        public string? Token { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- fix AuthResponse so JSON deserialization works

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545b3345fc83258d21a790006e78bf