### PR TITLE
Fix Robot CI trigger

### DIFF
--- a/.github/workflows/robot-python-ci.yml
+++ b/.github/workflows/robot-python-ci.yml
@@ -2,9 +2,7 @@ name: SpaceX Suite CI with Allure and Quality Gates
 
 on:
   push:
-    branches: [main, master]
   pull_request:
-    branches: [main, master]
   schedule:
     - cron: '0 4 * * *'
 
@@ -47,7 +45,7 @@ jobs:
         run: black --check .
 
   api-tests:
-    name: Test: API Suite
+    name: "Test: API Suite"
     runs-on: ubuntu-latest
     needs: lint-and-quality
     steps:
@@ -83,7 +81,7 @@ jobs:
           path: ${{ env.TESTS_DIR }}/reports/api_pabot
 
   gui-visual-tests:
-    name: Test: GUI & Visual Suite
+    name: "Test: GUI & Visual Suite"
     runs-on: ubuntu-latest
     needs: lint-and-quality
     steps:
@@ -118,7 +116,7 @@ jobs:
           path: ${{ env.TESTS_DIR }}/reports/gui_visual_results
 
   unit-tests:
-    name: Test: Pytest Unit Suite
+    name: "Test: Pytest Unit Suite"
     runs-on: ubuntu-latest
     needs: lint-and-quality
     steps:
@@ -149,7 +147,7 @@ jobs:
           path: ${{ env.TESTS_DIR }}/pytest_unit
 
   generate-allure-report:
-    name: Reporting: Allure Merge & Upload
+    name: "Reporting: Allure Merge & Upload"
     runs-on: ubuntu-latest
     needs: [api-tests, gui-visual-tests, unit-tests]
     steps:


### PR DESCRIPTION
## Summary
- trigger Robot CI on all branches
- quote job names containing colons to fix YAML syntax

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/robot-python-ci.yml")'`
- `make lint-all` *(fails: Could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68568e7998bc8325a5f940ceb69e0fee