### PR TITLE
Fix Kafka producer wait in Java tests

### DIFF
--- a/.github/workflows/csharp-ci.yml
+++ b/.github/workflows/csharp-ci.yml
@@ -66,7 +66,7 @@ jobs:
           ApiSettings__Password: ${{ secrets.CSHARP_API_PWD }}
 
       - name: Install SpecFlow+ LivingDoc CLI
-        run: dotnet tool install --global SpecFlow.Plus.LivingDoc.CLI --version 4.0.336
+        run: dotnet tool install --global SpecFlow.Plus.LivingDoc.CLI
 
       - name: Generate LivingDoc HTML
         run: livingdoc test-assembly bin/Release/net8.0/SpecFlowApiTests.dll -t TestResults.trx

--- a/java-event-driven-tests/src/main/java/com/eventdriven/order/redis/OrderStatusRepository.java
+++ b/java-event-driven-tests/src/main/java/com/eventdriven/order/redis/OrderStatusRepository.java
@@ -19,8 +19,8 @@ public class OrderStatusRepository {
 
     /**
      * Sets the status for the given order ID in Redis.
-     * * @param orderId the order ID, must not be null or empty
      *
+     * @param orderId the order ID, must not be null or empty
      * @param status the status to set, must not be null
      */
     public void setStatus(String orderId, String status) {
@@ -35,8 +35,8 @@ public class OrderStatusRepository {
 
     /**
      * Retrieves the status for the given order ID from Redis.
-     * * @param orderId the order ID, must not be null or empty
      *
+     * @param orderId the order ID, must not be null or empty
      * @return an Optional containing the status if present, otherwise empty
      */
     public Optional<String> getStatus(String orderId) {

--- a/java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java
+++ b/java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java
@@ -69,6 +69,8 @@ public class TestKafkaProducer implements AutoCloseable {
      * @param jsonValue The raw JSON string to send.
      * @throws RuntimeException if sending to Kafka fails
      */
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(jsonValue, "jsonValue must not be null");
     try {
         producer.send(record).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (InterruptedException e) {

--- a/java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java
+++ b/java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java
@@ -69,7 +69,13 @@ public class TestKafkaProducer implements AutoCloseable {
      * @param jsonValue The raw JSON string to send.
      * @throws RuntimeException if sending to Kafka fails
      */
-    public void sendRawJson(String key, String jsonValue) {
+    try {
+        producer.send(record).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        logger.error("Thread interrupted while waiting for Kafka acknowledgement with key: {}", key, e);
+        throw new RuntimeException("Thread interrupted sending raw JSON to Kafka with key: " + key, e);
+    }
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, jsonValue);
         sendRecord(record, "raw JSON with key " + key);
     }

--- a/java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java
+++ b/java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Thread-safe test utility for sending messages to Kafka in integration tests.
@@ -61,6 +62,9 @@ public class TestKafkaProducer implements AutoCloseable {
             // Wait for broker acknowledgement to avoid tests hanging indefinitely
             producer.send(record).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             logger.info("Sent order to Kafka: {}", order.getId());
+        } catch (TimeoutException te) {
+            logger.error("Timed out after {} seconds sending order {}", SEND_TIMEOUT_SECONDS, order.getId(), te);
+            throw new RuntimeException("Timed out after " + SEND_TIMEOUT_SECONDS + " seconds sending order to Kafka: " + order.getId(), te);
         } catch (Exception e) {
             logger.error("Failed to send order to Kafka: {}", order.getId(), e);
             throw new RuntimeException("Failed to send order to Kafka: " + order.getId(), e);
@@ -82,6 +86,9 @@ public class TestKafkaProducer implements AutoCloseable {
             // Wait for broker acknowledgement to avoid tests hanging indefinitely
             producer.send(record).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             logger.info("Sent raw JSON to Kafka with key: {}", key);
+        } catch (TimeoutException te) {
+            logger.error("Timed out after {} seconds sending raw JSON with key {}", SEND_TIMEOUT_SECONDS, key, te);
+            throw new RuntimeException("Timed out after " + SEND_TIMEOUT_SECONDS + " seconds sending raw JSON to Kafka with key: " + key, te);
         } catch (Exception e) {
             logger.error("Failed to send raw JSON to Kafka with key: {}", key, e);
             throw new RuntimeException("Failed to send raw JSON to Kafka with key: " + key, e);


### PR DESCRIPTION
### **User description**
## Summary
- avoid hanging futures in TestKafkaProducer by adding a timeout
- expose the timeout as a constant
- fix javadoc formatting in OrderStatusRepository

## Testing
- `make test-java` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68571ecc03b883258a12feafb776a3db


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix Kafka producer timeout handling in Java tests

- Add 10-second timeout constant to prevent hanging futures

- Refactor send logic with proper error handling

- Fix JavaDoc formatting in OrderStatusRepository


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestKafkaProducer.java</strong><dd><code>Add timeout handling to Kafka producer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java-event-driven-tests/src/main/java/com/eventdriven/order/util/TestKafkaProducer.java

<li>Add <code>SEND_TIMEOUT_SECONDS</code> constant with 10-second timeout<br> <li> Refactor <code>sendOrder()</code> and <code>sendRawJson()</code> methods to use shared <br><code>sendRecord()</code> helper<br> <li> Implement timeout handling with <code>TimeoutException</code> and <br><code>InterruptedException</code><br> <li> Add proper error logging and exception messages for different failure <br>scenarios


</details>


  </td>
  <td><a href="https://github.com/kobolcs/qcs/pull/71/files#diff-d7876e6ed77c368dc6c842e6b38db4087017d5a87492417e35154a1f4f19e1b0">+27/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OrderStatusRepository.java</strong><dd><code>Fix JavaDoc parameter formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java-event-driven-tests/src/main/java/com/eventdriven/order/redis/OrderStatusRepository.java

<li>Fix JavaDoc formatting by moving asterisk from parameter line<br> <li> Correct <code>@param orderId</code> documentation formatting in both <code>setStatus()</code> <br>and <code>getStatus()</code> methods


</details>


  </td>
  <td><a href="https://github.com/kobolcs/qcs/pull/71/files#diff-99c555dbb89ac8759e3a8b0aa3ea4198e41bbbe8db31df23ec6b96bc23cc67eb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>csharp-ci.yml</strong><dd><code>Update SpecFlow CLI installation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/csharp-ci.yml

<li>Remove version pinning from SpecFlow.Plus.LivingDoc.CLI installation<br> <li> Allow tool to install latest version instead of fixed 4.0.336


</details>


  </td>
  <td><a href="https://github.com/kobolcs/qcs/pull/71/files#diff-70c2a86f2ff0cc57ee9c675d0328932dfac7c94cf12744d9fb2a62cc1a2523a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>