### PR TITLE
Update Java event-driven tests Dockerfile to JDK 21

### DIFF
--- a/java-event-driven-tests/Dockerfile
+++ b/java-event-driven-tests/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application using Maven
-FROM maven:3.9-eclipse-temurin-17 AS build
+FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
@@ -7,7 +7,7 @@ COPY src ./src
 RUN mvn clean install -DskipTests
 
 # Stage 2: Create the final lightweight runtime image
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 # Copy the executable JAR from the build stage
 COPY --from=build /app/target/*.jar app.jar

--- a/java-event-driven-tests/README.md
+++ b/java-event-driven-tests/README.md
@@ -28,7 +28,7 @@ The **Testcontainers** pattern of managing ephemeral test dependencies in code i
 ### Installation and Running
 
 **Prerequisites:**
-* Java Development Kit (JDK) 17 or later
+* Java Development Kit (JDK) 21 or later
 * Apache Maven
 * Docker Desktop (for Testcontainers)
 


### PR DESCRIPTION
## Summary
- update Dockerfile for `java-event-driven-tests` to use JDK 21 images
- adjust README to state JDK 21 requirement

## Testing
- `docker build -t java-event-driven-tests java-event-driven-tests` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857d546a58c8325aa230f8f20769475