### PR TITLE
Remove redpanda dependency from Java tests

### DIFF
--- a/java-event-driven-tests/pom.xml
+++ b/java-event-driven-tests/pom.xml
@@ -63,12 +63,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>redpanda</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.15.3</version>


### PR DESCRIPTION
### **User description**
## Summary
- remove `org.testcontainers:redpanda` from the Java event-driven tests POM

## Testing
- `mvn -q validate` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d55c4fe08325bf7d753d3cacf02c


___

### **PR Type**
Other


___

### **Description**
- Remove unused `org.testcontainers:redpanda` dependency from Java event-driven tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Remove redpanda testcontainers dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

java-event-driven-tests/pom.xml

<li>Removed <code>org.testcontainers:redpanda</code> dependency block from Maven POM


</details>


  </td>
  <td><a href="https://github.com/kobolcs/qcs/pull/74/files#diff-4f6a16eefd6900e908b31a02cd1aacb0292f9d93e0c94de42dd5e1e624ce7105">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>