### PR TITLE
Automate report publishing

### DIFF
--- a/.github/workflows/collect-reports.yml
+++ b/.github/workflows/collect-reports.yml
@@ -1,0 +1,85 @@
+name: Collect and Publish Reports
+
+on:
+  workflow_run:
+    workflows:
+      - "C# Build, Test, and Deploy LivingDoc"
+      - "Playwright TS CI"
+      - "SpaceX Suite CI with Allure and Quality Gates"
+      - "k6 Performance Test"
+      - "Java Event-Driven CI"
+      - "Elixir API Tests - CI & Report"
+      - "Mobile CI (Appium)"
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  collect:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download artifact from triggering workflow
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          path: artifacts
+
+      - name: Organize downloaded report
+        run: |
+          mkdir -p docs/reports
+          case "${{ github.event.workflow_run.name }}" in
+            "C# Build, Test, and Deploy LivingDoc")
+              mkdir -p docs/reports/csharp
+              cp artifacts/living-doc/LivingDoc.html docs/reports/csharp/index.html
+              ;;
+            "Playwright TS CI")
+              mkdir -p docs/reports/playwright
+              if [ -d artifacts/playwright-report/playwright-report ]; then
+                mv artifacts/playwright-report/playwright-report/* docs/reports/playwright/
+              else
+                mv artifacts/playwright-report/* docs/reports/playwright/
+              fi
+              ;;
+            "SpaceX Suite CI with Allure and Quality Gates")
+              mkdir -p docs/reports/allure
+              mv artifacts/allure-report/* docs/reports/allure/
+              ;;
+            "k6 Performance Test")
+              mkdir -p docs/reports/k6
+              cp artifacts/k6-summary/summary.html docs/reports/k6/index.html
+              ;;
+            "Java Event-Driven CI")
+              mkdir -p docs/reports/java
+              if ls artifacts/test-reports-*/target/site 1>/dev/null 2>&1; then
+                cp -r artifacts/test-reports-*/target/site/* docs/reports/java/
+              fi
+              ;;
+            "Elixir API Tests - CI & Report")
+              mkdir -p docs/reports/elixir
+              mv artifacts/elixir-reports/* docs/reports/elixir/
+              ;;
+            "Mobile CI (Appium)")
+              mkdir -p docs/reports/mobile
+              mv artifacts/mobile-test-artifacts/* docs/reports/mobile/
+              ;;
+          esac
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/dashboard.md
+++ b/dashboard.md
@@ -1,26 +1,26 @@
 # 🧭 Portfolio Dashboard
 
-Welcome to the at-a-glance view of this cross-language test automation consultant portfolio. All CI badges are live and all reports are available as downloadable artifacts from the latest CI run.
+Welcome to the at-a-glance view of this cross-language test automation consultant portfolio. All CI badges are live and each project publishes its latest report under `docs/reports/`.
 
 ---
 
 ## 🔖 Projects and Badges
 
-* ![C# SpecFlow API Tests](https://github.com/kobolcs/qcs/actions/workflows/csharp-ci.yml/badge.svg) **C# SpecFlow**: [README](csharp-specflow-api-tests/README.md) | **Report:** See `LivingDoc.html` artifact from CI run.
+* ![C# SpecFlow API Tests](https://github.com/kobolcs/qcs/actions/workflows/csharp-ci.yml/badge.svg) **C# SpecFlow**: [README](csharp-specflow-api-tests/README.md) | **Report:** [Live report](https://kobolcs.github.io/qcs/reports/csharp/)
 
-* ![Go API Tests](https://github.com/kobolcs/qcs/actions/workflows/go-ci.yml/badge.svg) **Go API Tests**: [README](go-api-tests/README.md) | **Report:** See `weather_test_report.json` artifact from CI run.
+* ![Go API Tests](https://github.com/kobolcs/qcs/actions/workflows/go-ci.yml/badge.svg) **Go API Tests**: [README](go-api-tests/README.md)
 
-* ![Java Event-Driven CI](https://github.com/kobolcs/qcs/actions/workflows/java-ci.yml/badge.svg) **Java Event-Driven**: [README](java-event-driven-tests/README.md) | **Report:** See Surefire reports artifact from CI run.
+* ![Java Event-Driven CI](https://github.com/kobolcs/qcs/actions/workflows/java-ci.yml/badge.svg) **Java Event-Driven**: [README](java-event-driven-tests/README.md) | **Report:** [Live report](https://kobolcs.github.io/qcs/reports/java/)
 
-* ![Playwright TS CI](https://github.com/kobolcs/qcs/actions/workflows/playwright-ci.yml/badge.svg) **Playwright+TS**: [README](playwright-ts-api-test/README.md) | **Report:** See `playwright-report` artifact from CI run.
+* ![Playwright TS CI](https://github.com/kobolcs/qcs/actions/workflows/playwright-ci.yml/badge.svg) **Playwright+TS**: [README](playwright-ts-api-test/README.md) | **Report:** [Live report](https://kobolcs.github.io/qcs/reports/playwright/)
 
 * ![Pact Contract Test](https://github.com/kobolcs/qcs/actions/workflows/pact-ci.yml/badge.svg) **Pact Contract-Testing**: [README](pact-contract-testing/README.md)
 
-* ![k6 Performance Test](https://github.com/kobolcs/qcs/actions/workflows/k6-ci.yml/badge.svg) **Performance (k6)**: [README](k6-performance-tests/README.md) | **Report:** See `summary.html` artifact from CI run.
+* ![k6 Performance Test](https://github.com/kobolcs/qcs/actions/workflows/k6-ci.yml/badge.svg) **Performance (k6)**: [README](k6-performance-tests/README.md) | **Report:** [Live report](https://kobolcs.github.io/qcs/reports/k6/)
 
-* ![Robot Framework Python Tests](https://github.com/kobolcs/qcs/actions/workflows/robot-python-ci.yml/badge.svg) **Robot+Python**: [README](robot-framework-python-tests/README.md) | **Report:** See `allure-report` artifact from CI run.
+* ![Robot Framework Python Tests](https://github.com/kobolcs/qcs/actions/workflows/robot-python-ci.yml/badge.svg) **Robot+Python**: [README](robot-framework-python-tests/README.md) | **Report:** [Live report](https://kobolcs.github.io/qcs/reports/allure/)
 
-* ![Elixir API Tests](https://github.com/kobolcs/qcs/actions/workflows/elixir_ci.yml/badge.svg) **Elixir API**: [README](elixir-api-tests/README.md) | **Report:** See `elixir-reports` artifact from CI run.
+* ![Elixir API Tests](https://github.com/kobolcs/qcs/actions/workflows/elixir_ci.yml/badge.svg) **Elixir API**: [README](elixir-api-tests/README.md) | **Report:** [Live report](https://kobolcs.github.io/qcs/reports/elixir/)
 
 ---
 


### PR DESCRIPTION
## Summary
- create a workflow that gathers CI artifacts and publishes them to GitHub Pages
- link Portfolio Dashboard directly to the live HTML reports

## Testing
- `make lint-go`

------
https://chatgpt.com/codex/tasks/task_e_6864f882b4e08325a91a68087db4d5ea