### PR TITLE
Fix deprecated logger usage

### DIFF
--- a/robot-framework-python-tests/helpers/self_heal.py
+++ b/robot-framework-python-tests/helpers/self_heal.py
@@ -22,5 +22,5 @@ def click_with_fallback(selectors):
             logger.info(f"Clicked using selector: {sel}")
             return sel
         except Exception as e:
-            logger.warn(f"Selector failed: {sel}: {e}")
+            logger.warning(f"Selector failed: {sel}: {e}")
     raise Exception("None of the selectors worked")


### PR DESCRIPTION
### **User description**
## Summary
- use `logger.warning` instead of deprecated `logger.warn`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'robot')*

------
https://chatgpt.com/codex/tasks/task_e_6865ffe68a94832590e83909001930b4


___

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated `logger.warn` with `logger.warning`


___

### **Changes diagram**

```mermaid
flowchart LR
  A["logger.warn"] -- "replace with" --> B["logger.warning"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>self_heal.py</strong><dd><code>Fix deprecated logger method usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

robot-framework-python-tests/helpers/self_heal.py

<li>Replace deprecated <code>logger.warn</code> with <code>logger.warning</code> in exception <br>handling


</details>


  </td>
  <td><a href="https://github.com/kobolcs/qcs/pull/109/files#diff-d336ac2a5a476e90ca2fd6fe8b8cbffdff7a0c3040c87abca2f6bacb4c9b1c64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>